### PR TITLE
docs(readme): agregar integrantes y relevamiento sprint 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Pasos para docentes y alumnos: [docs/taller/github-classroom-y-template.md](docs
 
 Completar con el enlace real al **GitHub Project**:
 
-**Tablero:** [Ver tablero] (https://github.com/orgs/UCSE-Programacion-2/projects/12)
+**Tablero:** [Ver tablero](https://github.com/orgs/UCSE-Programacion-2/projects/12)
 
 ## Integrantes (obligatorio: 3 por equipo)
 
-- **Apellido, Nombre** — [GitHub](https://github.com/)
-- **Apellido, Nombre** — [GitHub](https://github.com/)
-- **Apellido, Nombre** — [GitHub](https://github.com/)
+- **Matos, Francisco** — [GitHub](https://github.com/MacetaXL)
+- **Vilca, Lucas** — [GitHub](https://github.com/AlvaroLucas778)
+- **Maizares, Mauricio** — [GitHub](https://github.com/0mgm)
 
 ## Reglas de contribución (alineadas al integrador)
 

--- a/docs/sprint-0/relevamiento.md
+++ b/docs/sprint-0/relevamiento.md
@@ -1,0 +1,16 @@
+# Relevamiento Sprint 0 — Rent&Go
+
+## Qué ofrece la empresa
+Rent&Go es una agencia de alquiler de vehículos. Los clientes pueden 
+reservar autos, camionetas o motos por el tiempo que necesiten.
+
+## Problemas detectados
+1. Las reservas se hacen por teléfono o en persona, no hay sistema online.
+2. No se sabe en tiempo real qué vehículos están disponibles.
+3. Los pagos y registros se manejan a mano, lo que genera errores.
+
+## Qué va a resolver la app
+- Que los clientes puedan reservar un vehículo desde la web.
+- Ver qué vehículos están disponibles en qué fechas.
+- Registrar pagos y generar comprobantes automáticamente.
+- Que los empleados puedan gestionar la flota y las reservas desde un panel.


### PR DESCRIPTION
## Qué se hizo
Se actualizó el README con los integrantes del equipo y se creó el archivo de relevamiento del Sprint 0 para Rent&Go.

## Por qué
Documentación inicial del proyecto requerida para el Sprint 0.
Closes #1

## Vinculación obligatoria
- Issue / Tarjeta en GitHub Projects: `#1`
- Sprint: `Sprint 0`
- Rama: `readme-y-relevamiento`

## Cómo probar
1. Verificar que en el README aparecen los 3 integrantes con sus links.
2. Verificar que existe el archivo docs/sprint-0/relevamiento.md.

## Uso de IA
Se usó IA para el revisado y adaptado al contexto del proyecto.

## Notas para el reviewer
Ninguna.

## Checklist (Definition of Done)
- [x] Cumple el enunciado del sprint indicado
- [x] Hay evidencia de prueba (tests o pasos manuales)
- [x] No se subieron secretos (`.env`, credenciales, claves)
- [x] Los commits siguen Conventional Commits (`type(scope): ...`)
- [x] El PR referencia el issue con `Closes #N`